### PR TITLE
Handle Preprocessing for Descending Time Series Data

### DIFF
--- a/autots/evaluator/auto_ts.py
+++ b/autots/evaluator/auto_ts.py
@@ -693,7 +693,7 @@ class AutoTS(object):
                 id_col=self.id_col,
                 aggfunc=self.aggfunc,
             )
-
+            df_wide = df_wide.sort_index(ascending=True)  
         df_wide = df_cleanup(
             df_wide,
             frequency=self.frequency,

--- a/autots/tools/shaping.py
+++ b/autots/tools/shaping.py
@@ -59,9 +59,6 @@ def df_cleanup(
         if sum(dupes) > 0:
             print("Warning, series ids are not unique: {df_wide.columns[dupes]}")
 
-    # make sure time series is in ascending order to infer frequency  
-    df_wide.sort_index(inplace=True)
-
     # infer frequency
     if frequency == 'infer':
         frequency = infer_frequency(df_wide)

--- a/autots/tools/shaping.py
+++ b/autots/tools/shaping.py
@@ -59,6 +59,9 @@ def df_cleanup(
         if sum(dupes) > 0:
             print("Warning, series ids are not unique: {df_wide.columns[dupes]}")
 
+    # make sure time series is in ascending order to infer frequency  
+    df_wide.sort_index(inplace=True)
+
     # infer frequency
     if frequency == 'infer':
         frequency = infer_frequency(df_wide)


### PR DESCRIPTION
## Detected Unintuitive Behaviour

I ran into a weird error when passing in a dataframe with a descending date index.

`ValueError: attempt to get argmax of an empty sequence`

## Root Cause

`autots.tools.shaping.df_cleanup` is returning an empty dataframe because the inferred frequency of `-1H` results in unexpected behaviour when filling missing dates.


Example:
<img width="384" alt="Screenshot 2022-09-27 at 19 25 35" src="https://user-images.githubusercontent.com/13679375/192654756-7c912312-de96-416a-8221-88ccdcda0da1.png">


## Proposed Change

Let's make sure to sort the time series in ascending order at the beginning of the cleanup for additional robustness and avoid the mystery error message. This also guarantees compatibility with Prophet, which can handle unordered time series data.
