### PR TITLE
FILLNA -> FFILL, BFILL, axis argument removal and addition of StringIO object

### DIFF
--- a/autots/datasets/_base.py
+++ b/autots/datasets/_base.py
@@ -416,7 +416,7 @@ def load_live_daily(
                 report = "domain"  # site, domain, download, second-level-domain
                 url = f"https://api.gsa.gov/analytics/dap/v1.1/domain/{domain}/reports/{report}/data?api_key={gsa_key}&limit={gov_domain_limit}&after={observation_start}"
                 data = s.get(url, timeout=timeout)
-                gdf = pd.read_json(data.text, orient="records")
+                gdf = pd.read_json(io.StringIO(data.text), orient="records")
                 gdf['date'] = pd.to_datetime(gdf['date'])
                 # essentially duplicates brought by agency and null agency
                 gresult = gdf.groupby('date')['visits'].first()

--- a/autots/models/cassandra.py
+++ b/autots/models/cassandra.py
@@ -436,7 +436,7 @@ class Cassandra(ModelObject):
                 )
             elif self.multivariate_feature == "group_average":
                 multivar_df = (
-                    trs_df.groupby(self.categorical_groups, axis=1)
+                    trs_df.T.groupby(self.categorical_groups)
                     .mean()
                     .iloc[lag_1_indx]
                 )
@@ -890,7 +890,7 @@ class Cassandra(ModelObject):
                 )
             elif self.multivariate_feature == "group_average":
                 multivar_df = (
-                    trs_df.groupby(self.categorical_groups, axis=1)
+                    trs_df.T.groupby(self.categorical_groups)
                     .mean()
                     .iloc[lag_1_indx]
                 )

--- a/autots/models/sklearn.py
+++ b/autots/models/sklearn.py
@@ -103,7 +103,7 @@ def rolling_x_regressor(
             local_df.index.shift(-nonzero_last_n, freq=inferred_freq)
         )
         X.append(
-            (local_df.reindex(full_index).fillna(method="bfill") != 0)
+            (local_df.reindex(full_index).bfill() != 0)
             .rolling(nonzero_last_n, min_periods=1)
             .sum()
             .reindex(local_df.index)

--- a/autots/tools/hierarchial.py
+++ b/autots/tools/hierarchial.py
@@ -72,7 +72,7 @@ class hierarchial(object):
         self.top_ids = set(grouping_ids.values())
         self.bottom_ids = grouping_ids.keys()
 
-        hier = df.abs().groupby(grouping_ids, axis=1).sum()
+        hier = df.abs().T.groupby(grouping_ids).sum()
         self.hier = hier
 
         if self.reconciliation == 'mean':
@@ -115,7 +115,7 @@ class hierarchial(object):
 
             top_level = fore[self.top_ids]
             bottom_up = (
-                fore[self.bottom_ids].abs().groupby(self.grouping_ids, axis=1).sum()
+                fore[self.bottom_ids].abs().T.groupby(self.grouping_ids).sum()
             )
 
             diff = (top_level - bottom_up) / 2

--- a/autots/tools/transform.py
+++ b/autots/tools/transform.py
@@ -2397,9 +2397,7 @@ class MeanDifference(EmptyTransformer):
         Args:
             df (pandas.DataFrame): input dataframe
         """
-        return (df - df.mean(axis=1).shift(self.lag).values[..., None]).fillna(
-            method="bfill"
-        )
+        return (df - df.mean(axis=1).shift(self.lag).values[..., None]).bfill()
 
     def fit_transform(self, df):
         """Fits and Returns Magical DataFrame
@@ -2407,9 +2405,7 @@ class MeanDifference(EmptyTransformer):
             df (pandas.DataFrame): input dataframe
         """
         self.fit(df)
-        return (df - self.means.shift(self.lag).values[..., None]).fillna(
-            method="bfill"
-        )
+        return (df - self.means.shift(self.lag).values[..., None]).bfill()
 
     def inverse_transform(self, df, trans_method: str = "forecast"):
         """Returns data to original *or* forecast form
@@ -4118,7 +4114,7 @@ def exponential_decay(n, span=None, halflife=None):
         decay_values = np.exp(-t / span)
     else:
         decay_values = np.exp(-np.log(2) * t / halflife)
-    
+
     return decay_values
 
 
@@ -4168,7 +4164,7 @@ class AlignLastDiff(EmptyTransformer):
             local_df = df.ffill(axis=0)
         else:
             local_df = df
-        
+
         self.center = df.iloc[-1, :]
 
         if self.rows <= 1:
@@ -4201,7 +4197,7 @@ class AlignLastDiff(EmptyTransformer):
             self.adjustment = adjustment
         if trans_method == "original":
             return df
-        
+
 
         if self.adjustment is None:
             displacement = df.iloc[0] - self.center  # positive is growth

--- a/production_example.py
+++ b/production_example.py
@@ -159,7 +159,7 @@ if 'wiki_all' in df.columns:
 if trend_list is not None:
     for tx in trend_list:
         if tx in df.columns:
-            df[tx] = df[tx].interpolate('akima').fillna(method='ffill', limit=30).fillna(method='bfill', limit=30)
+            df[tx] = df[tx].interpolate('akima').ffill(limit=30).bfill(limit=30)
 # fill weekends
 if tickers is not None:
     for fx in tickers:
@@ -176,7 +176,7 @@ if weather_event_types is not None:
     df[wevnt] = df[wevnt].mask(df[wevnt].notnull().cummax(), df[wevnt].fillna(0))
 # most of the NaN here are just weekends, when financial series aren't collected, ffill of a few steps is fine
 # partial forward fill, no back fill
-df = df.fillna(method='ffill', limit=3)
+df = df.ffill(limit=3)
 
 df = df[df.index.year > 1999]
 # remove any data from the future


### PR DESCRIPTION
## Changes
Per the updates in Panadas 2.10, fillna should be replaced with ffill and bfill whenever possible:
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.fillna.html

And groupby no longer uses the axis argument
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html

I also added a missing StringIO object around, per the warnings.

## Relevant Issues and Mentions
N/A

## Notes

These are very very minor changes, but I figured it would be best to start small, fix some of the warnings that pop-up when a user runs the example python script.

