### PR TITLE
Update auto_ts.py add absolute value in the MAPE formula

### DIFF
--- a/autots/evaluator/auto_ts.py
+++ b/autots/evaluator/auto_ts.py
@@ -3397,6 +3397,7 @@ class AutoTS(object):
         scaler[scaler == 0] == 1
         temp = (
             ((best_model_per_series_mae / scaler) * 100)
+            .abs()
             .round(2)
             .sort_values(ascending=False)
         )


### PR DESCRIPTION
I think the MAPE metric cannot be negative. The formula takes absolute value. Added abs() to fix that.

## Changes

## Relevant Issues and Mentions
