### PR TITLE
Update python_requires to version 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.9',
+    python_requires='>=3.10',
 )


### PR DESCRIPTION
The '|' syntax usage in AutoTS 1.0.0 is not supported by python 3.9.

## Relevant Issues and Mentions
#268 