### PR TITLE
Fix null transformation names and malformed strings in general_template_dict

### DIFF
--- a/autots/templates/general.py
+++ b/autots/templates/general.py
@@ -175,7 +175,7 @@ general_template_dict = {
     "29": {
         "Model": "SectionalMotif",
         "ModelParameters": "{\"window\": 10, \"point_method\": \"weighted_mean\", \"distance_metric\": \"sokalmichener\", \"include_differenced\": true, \"k\": 20, \"stride_size\": 1, \"regression_type\": null}",
-        "TransformationParameters": "{\"fillna\": \"zero\", \"transformations\": {\"0\": null}, \"transformation_params\": {\"0\": {}}}",
+        "TransformationParameters": "{\"fillna\": \"zero\", \"transformations\": {\"0\": \"None\"}, \"transformation_params\": {\"0\": {}}}",
         "Ensemble": 0,
     },
     "30": {
@@ -282,9 +282,7 @@ general_template_dict = {
             "num_split": 4, "min_num_epochs": 5, "train_epochs": 40,
             "epoch_len": null, "permute": true, "normalize": false
         }''',
-        'TransformationParameters': '''
-        {"fillna": "ffill", "transformations": {"0": "AlignLastValue", "1": "Log", "2": "AlignLastValue", "3": "MinMaxScaler"}, "transformation_params": {"0": {"rows": 4, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "1": {}, "2": {"rows": 1, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "3": {}}}
-        ''',
+        'TransformationParameters': '{"fillna": "ffill", "transformations": {"0": "AlignLastValue", "1": "Log", "2": "AlignLastValue", "3": "MinMaxScaler"}, "transformation_params": {"0": {"rows": 4, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "1": {}, "2": {"rows": 1, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "3": {}}}',
         'Ensemble': 0,
     },
     "44": {
@@ -314,25 +312,25 @@ general_template_dict = {
     "48": {  # optimized 200 minutes on initial model import on load_daily
         "Model": "DMD",
         'ModelParameters': '{"rank": 10, "alpha": 1, "amplitude_threshold": null, "eigenvalue_threshold": null}',
-        "TransformationParameters": '''{"fillna": "linear", "transformations": {"0": "HistoricValues", "1": "AnomalyRemoval", "2": "SeasonalDifference", "3": "AnomalyRemoval"},"transformation_params": {"0": {"window": 10}, "1": {"method": "zscore", "method_params": {"distribution": "norm", "alpha": 0.05}, "fillna": "ffill", "transform_dict": {"fillna": null, "transformations": {"0": "ClipOutliers"}, "transformation_params": {"0": {"method": "clip", "std_threshold": 6}}}, "isolated_only": false}, "2": {"lag_1": 7, "method": "Mean"}, "3": {"method": "zscore", "method_params": {"distribution": "norm", "alpha": 0.05}, "fillna": "fake_date", "transform_dict": {"transformations": {"0": "DifferencedTransformer"}, "transformation_params": {"0": {}}}, "isolated_only": false}}}''',
+        "TransformationParameters": '{"fillna": "linear", "transformations": {"0": "HistoricValues", "1": "AnomalyRemoval", "2": "SeasonalDifference", "3": "AnomalyRemoval"},"transformation_params": {"0": {"window": 10}, "1": {"method": "zscore", "method_params": {"distribution": "norm", "alpha": 0.05}, "fillna": "ffill", "transform_dict": {"fillna": null, "transformations": {"0": "ClipOutliers"}, "transformation_params": {"0": {"method": "clip", "std_threshold": 6}}}, "isolated_only": false}, "2": {"lag_1": 7, "method": "Mean"}, "3": {"method": "zscore", "method_params": {"distribution": "norm", "alpha": 0.05}, "fillna": "fake_date", "transform_dict": {"transformations": {"0": "DifferencedTransformer"}, "transformation_params": {"0": {}}}, "isolated_only": false}}}',
         "Ensemble": 0,
     },
     "49": {  # short optimization on M5
         "Model": "DMD",
-        "ModelParameters": '''{"rank": 2, "alpha": 1, "amplitude_threshold": null, "eigenvalue_threshold": 1}''',
-        "TransformationParameters": '''{"fillna": "ffill", "transformations": {"0": "SeasonalDifference", "1": "AlignLastValue", "2": "Round", "3": "Round", "4": "MinMaxScaler"}, "transformation_params": {"0": {"lag_1": 7, "method": "LastValue"}, "1": {"rows": 1, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "2": {"decimals": 0, "on_transform": false, "on_inverse": true}, "3": {"decimals": 0, "on_transform": false, "on_inverse": true}, "4": {}}}''',
+        "ModelParameters": '{"rank": 2, "alpha": 1, "amplitude_threshold": null, "eigenvalue_threshold": 1}',
+        "TransformationParameters": '{"fillna": "ffill", "transformations": {"0": "SeasonalDifference", "1": "AlignLastValue", "2": "Round", "3": "Round", "4": "MinMaxScaler"}, "transformation_params": {"0": {"lag_1": 7, "method": "LastValue"}, "1": {"rows": 1, "lag": 1, "method": "additive", "strength": 1.0, "first_value_only": false}, "2": {"decimals": 0, "on_transform": false, "on_inverse": true}, "3": {"decimals": 0, "on_transform": false, "on_inverse": true}, "4": {}}}',
         "Ensemble": 0,
     },
     "50": {
         'Model': 'NVAR',
         'ModelParameters': '{"k": 2, "ridge_param": 2e-06, "warmup_pts": 1, "seed_pts": 1, "seed_weighted": null, "batch_size": 5, "batch_method": "std_sorted"}',
-        'TransformationParameters': '{"fillna": "ffill", "transformations": {"0": "HolidayTransformer", "1": "PositiveShift"}, "transformation_params": {"0": {"threshold": 0.9, "splash_threshold": null, "use_dayofmonth_holidays": true, "use_wkdom_holidays": true, "use_wkdeom_holidays": false, "use_lunar_holidays": false, "use_lunar_weekday": false, "use_islamic_holidays": false, "use_hebrew_holidays": false, "anomaly_detector_params": {"method": "rolling_zscore", "method_params": {"distribution": "uniform", "alpha": 0.03, "rolling_periods": 300, "center": true}, "fillna": "ffill", "transform_dict": {"fillna": "nearest", "transformations": {"0": null}, "transformation_params": {"0": {}}}, "isolated_only": false}, "remove_excess_anomalies": true, "impact": "datepart_regression", "regression_params": {"regression_model": {"model": "ElasticNet", "model_params": {"l1_ratio": 0.1, "fit_intercept": true, "selection": "cyclic"}}, "datepart_method": "simple", "polynomial_degree": null, "transform_dict": null, "holiday_countries_used": false}}, "1": {}}}',
+        'TransformationParameters': '{"fillna": "ffill", "transformations": {"0": "HolidayTransformer", "1": "PositiveShift"}, "transformation_params": {"0": {"threshold": 0.9, "splash_threshold": null, "use_dayofmonth_holidays": true, "use_wkdom_holidays": true, "use_wkdeom_holidays": false, "use_lunar_holidays": false, "use_lunar_weekday": false, "use_islamic_holidays": false, "use_hebrew_holidays": false, "anomaly_detector_params": {"method": "rolling_zscore", "method_params": {"distribution": "uniform", "alpha": 0.03, "rolling_periods": 300, "center": true}, "fillna": "ffill", "transform_dict": {"fillna": "nearest", "transformations": {"0": "None"}, "transformation_params": {"0": {}}}, "isolated_only": false}, "remove_excess_anomalies": true, "impact": "datepart_regression", "regression_params": {"regression_model": {"model": "ElasticNet", "model_params": {"l1_ratio": 0.1, "fit_intercept": true, "selection": "cyclic"}}, "datepart_method": "simple", "polynomial_degree": null, "transform_dict": null, "holiday_countries_used": false}}, "1": {}}}',
         "Ensemble": 0,
     },
     "51": {  # optimized on M5, 60 SMAPE 2024-06-06
         'Model': 'BallTreeMultivariateMotif',
         'ModelParameters': '{"window": 28, "point_method": "median", "distance_metric": "euclidean", "k": 15}',
-        'TransformationParameters': '{"fillna": "ffill_mean_biased", "transformations": {"0": "QuantileTransformer", "1": "QuantileTransformer", "2": "DatepartRegression"}, "transformation_params": 	{"0": {"output_distribution": "uniform", "n_quantiles": 1000}, "1": {"output_distribution": "normal", "n_quantiles": 100}, "2": {"regression_model": {"model": "ElasticNet", "model_params": {"l1_ratio": 0.1, "fit_intercept": true, "selection": "cyclic"}}, "datepart_method": "expanded", "polynomial_degree": null, "transform_dict": null, "holiday_countries_used": false}}}',
+        'TransformationParameters': '{"fillna": "ffill_mean_biased", "transformations": {"0": "QuantileTransformer", "1": "QuantileTransformer", "2": "DatepartRegression"}, "transformation_params": {"0": {"output_distribution": "uniform", "n_quantiles": 1000}, "1": {"output_distribution": "normal", "n_quantiles": 100}, "2": {"regression_model": {"model": "ElasticNet", "model_params": {"l1_ratio": 0.1, "fit_intercept": true, "selection": "cyclic"}}, "datepart_method": "expanded", "polynomial_degree": null, "transform_dict": null, "holiday_countries_used": false}}}',
         "Ensemble": 0,
     },
     "52": {  # optimized on dap, 2.43 SMAPE 2024-06-20

--- a/tests/test_autots.py
+++ b/tests/test_autots.py
@@ -28,6 +28,48 @@ from autots.templates.general import general_template
 from autots.tools.cpu_count import cpu_count, set_n_jobs
 
 
+def find_null_transformation_names(obj, path=""):
+    """Recursively find null transformer names in any nested 'transformations' dict.
+
+    Templates nest transform dicts (e.g. HolidayTransformer's
+    anomaly_detector_params.transform_dict), so a single top-level check misses
+    bugs like GH #242, where a null transformer name several levels deep crashes
+    GeneralTransformer at runtime.
+    """
+    found = []
+    if isinstance(obj, dict):
+        transformations = obj.get("transformations")
+        if isinstance(transformations, dict):
+            for key, value in transformations.items():
+                if value is None:
+                    found.append(f"{path}/transformations/{key}")
+        for key, value in obj.items():
+            found.extend(find_null_transformation_names(value, f"{path}/{key}"))
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            found.extend(find_null_transformation_names(item, f"{path}[{idx}]"))
+    return found
+
+
+def find_transformation_key_mismatches(obj, path=""):
+    """Recursively find 'transformations'/'transformation_params' dicts with mismatched keys."""
+    mismatches = []
+    if isinstance(obj, dict):
+        transformations = obj.get("transformations")
+        transformation_params = obj.get("transformation_params")
+        if isinstance(transformations, dict) and isinstance(transformation_params, dict):
+            t_keys = set(transformations.keys())
+            p_keys = set(transformation_params.keys())
+            if t_keys != p_keys:
+                mismatches.append((path, t_keys, p_keys))
+        for key, value in obj.items():
+            mismatches.extend(find_transformation_key_mismatches(value, f"{path}/{key}"))
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            mismatches.extend(find_transformation_key_mismatches(item, f"{path}[{idx}]"))
+    return mismatches
+
+
 class AutoTSTest(unittest.TestCase):
     def test_autots(self):
         print("Starting AutoTS class tests")
@@ -813,6 +855,22 @@ class AutoTSTest(unittest.TestCase):
                 self.assertIsInstance(mod, dict)
                 self.assertIsInstance(trans, dict)
                 self.assertIsNotNone(ensemble)
+
+                null_transforms = find_null_transformation_names(trans)
+                self.assertEqual(
+                    null_transforms,
+                    [],
+                    f"Model {model} (index {index}) has null transformation name(s)"
+                    f" in TransformationParameters at: {null_transforms}",
+                )
+
+                key_mismatches = find_transformation_key_mismatches(trans)
+                self.assertEqual(
+                    key_mismatches,
+                    [],
+                    f"Model {model} (index {index}) has mismatched keys between"
+                    f" 'transformations' and 'transformation_params' at: {key_mismatches}",
+                )
 
     def test_custom_validations(self):
         long = False


### PR DESCRIPTION
## Summary

Fixes 6 data-quality bugs in `autots/templates/general.py`'s `general_template_dict`:

- **Entry 29**: `"transformations": {"0": null}` at the top level — a `null` transformer name can crash `GeneralTransformer` at runtime. Replaced with `"None"`, the no-op sentinel already registered in `trans_dict` (`autots/tools/transform.py`), matching the string-only convention used by every other entry.
- **Entry 43**: `TransformationParameters` was a triple-quoted multi-line string with leading/trailing whitespace. Collapsed to a clean single-line string, consistent with the rest of the file.
- **Entries 48 & 49**: removed unnecessary `'''triple-quoted'''` strings (their contents were already single-line JSON) in favor of the single-quoted style used everywhere else in the file.
- **Entry 50 (HolidayTransformer)**: nested `anomaly_detector_params.transform_dict.transformations.0 == null`, several levels deep inside `TransformationParameters`. This is the suspected root cause of #242 (`Error on HolidayTransformer since 0.6.12`), where a null-valued transformer buried inside a HolidayTransformer's anomaly detector config could break `GeneralTransformer.fit`. Replaced with `"None"`.
- **Entry 51**: removed a raw tab character embedded mid-string, between `"transformation_params":` and its value.

## Test changes

Extended `test_template` in `tests/test_autots.py` with two recursive checks run against every entry's parsed `TransformationParameters`:
1. `find_null_transformation_names` walks the full nested structure (not just the top level) looking for `null` values inside any `transformations` dict, so bugs like entry 50's — buried several levels deep — get caught.
2. `find_transformation_key_mismatches` checks that every `transformations` dict has the same keys as its sibling `transformation_params` dict, at every nesting level.

I verified both checks fail against the pre-fix template (flagging exactly entries 29 and 50) and pass after the fix.

## Test plan

- [x] `pytest tests/test_autots.py -k test_template -v` — 83 subtests pass
- [x] Confirmed the new assertions fail on the original (unfixed) `general.py`, catching entries 29 and 50
- [x] `pytest tests/test_autots.py --collect-only` — all 20 tests still collect without error

Refs #242